### PR TITLE
Remove id field from migrations

### DIFF
--- a/db/migrate/20150506145741_create_groups.rb
+++ b/db/migrate/20150506145741_create_groups.rb
@@ -1,7 +1,6 @@
 class CreateGroups < ActiveRecord::Migration
   def change
     create_table :groups do |t|
-      t.integer :id
       t.string :name
 
       t.timestamps null: false

--- a/db/migrate/20150506145755_create_users.rb
+++ b/db/migrate/20150506145755_create_users.rb
@@ -1,7 +1,6 @@
 class CreateUsers < ActiveRecord::Migration
   def change
     create_table :users do |t|
-      t.integer :id
       t.string :name
       t.integer :group_id
 

--- a/db/migrate/20150506145815_create_emails.rb
+++ b/db/migrate/20150506145815_create_emails.rb
@@ -1,7 +1,6 @@
 class CreateEmails < ActiveRecord::Migration
   def change
     create_table :emails do |t|
-      t.integer :id
       t.string :address
       t.integer :user_id
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,36 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20150506145815) do
+
+  create_table "emails", force: :cascade do |t|
+    t.string   "address"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string   "name"
+    t.integer  "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end


### PR DESCRIPTION
The 'id' field is defined by default, and
redefining it will throw an error that prevents
rails from running the migration.
