### PR TITLE
Fix duplicate fixture ids

### DIFF
--- a/test/fixtures/emails.yml
+++ b/test/fixtures/emails.yml
@@ -6,6 +6,6 @@ one:
   user_id: 1
 
 two:
-  id: 1
+  id: 2
   address: MyString
-  user_id: 1
+  user_id: 2

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -5,5 +5,5 @@ one:
   name: MyString
 
 two:
-  id: 1
+  id: 2
   name: MyString

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -6,6 +6,6 @@ one:
   group_id: 1
 
 two:
-  id: 1
+  id: 2
   name: MyString
   group_id: 1

--- a/test/models/email_test.rb
+++ b/test/models/email_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
 
 class EmailTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "init" do
+    @email = Email.create
+    assert true
+  end
 end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
 
 class GroupTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "init" do
+    @group = Group.create
+    assert true
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "init" do
+    @user = User.create
+    assert true
+  end
 end


### PR DESCRIPTION
The fixtures for groups, users, and emails
contain duplicate ids that will error out tests.
The included tests demonstrate the fixtures
being used for each table.
